### PR TITLE
Fixa problemas com two-way data binding no google-map-marker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,9 @@
     "iron-flex-layout": "^1.3.1",
     "google-apis": "GoogleWebComponents/google-apis#^1.1.6",
     "iron-icons": "^1.1.3",
-    "google-map": "klarkc/google-map#master",
     "paper-styles": "^1.1.4",
-    "icon-rate": "^1.1.2"
+    "icon-rate": "^1.1.2",
+    "iron-input": "^1.0.10",
+    "google-map": "klarkc/google-map#UseDOMInMarkers"
   }
 }

--- a/elements/work-places.html
+++ b/elements/work-places.html
@@ -33,7 +33,7 @@
             icon-fill-color="yellow"
             icon-scale="{{_getScale(item.rate)}}">
             <h2>{{item.name}}</h2>
-            <icon-rate rate$="{{item.rate}}" interactive></icon-rate>
+            <icon-rate rate="{{item.rate}}" interactive></icon-rate>
           </google-map-marker>
         </template>
       </google-map>
@@ -50,12 +50,11 @@
             value: {lat: undefined, lon: undefined, zoom: undefined}
           }
         },
-        _getScale: function(rate) {
-          // Scale between 1 and 2, for rate between 1 and 5
-          var scale = (rate + 3) / 4;
-          if(scale<1) return 1;
-          if(scale>2) return 2;
-          return scale;
+        observers: [
+          '_placesChanged(places.*)'
+        ],
+        _placesChanged: function(changeRecord) {
+          console.log('places changed', changeRecord);
         }
     });
     </script>

--- a/elements/work-places.html
+++ b/elements/work-places.html
@@ -23,7 +23,12 @@
         };
       }
       </style>
-      <google-map latitude="{{area.lat}}" longitude="{{area.lon}}" zoom="{{area.zoom}}">
+      <google-map
+        latitude="{{area.lat}}"
+        longitude="{{area.lon}}"
+        zoom="{{area.zoom}}"
+        single-info-window>
+
         <template is="dom-repeat" items="{{places}}">
           <google-map-marker
             latitude="{{item.lat}}"
@@ -36,6 +41,7 @@
             <icon-rate rate="{{item.rate}}" interactive></icon-rate>
           </google-map-marker>
         </template>
+        
       </google-map>
     </template>
     <script>

--- a/elements/work-places.html
+++ b/elements/work-places.html
@@ -54,7 +54,14 @@
           '_placesChanged(places.*)'
         ],
         _placesChanged: function(changeRecord) {
-          console.log('places changed', changeRecord);
+          console.log(changeRecord.path, 'changed to', changeRecord.value);
+        },
+        _getScale: function(rate) {
+          // Scale between 1 and 2, for rate between 1 and 5
+          var scale = (rate + 3) / 4;
+          if(scale<1) return 1;
+          if(scale>2) return 2;
+          return scale;
         }
     });
     </script>


### PR DESCRIPTION
Esse é um problema conhecido, os componentes (como o nosso icon-rate) não são passados com seus eventos para o google-map-marker, por causa de uma limitação da API do Google. Esse PR contém um workaround com uma versão customizada do elemento google-map que permite a utilização de qualquer web-componente dentro do google-map-marker.
